### PR TITLE
fastify printRoutes and close with promise

### DIFF
--- a/print-routes.js
+++ b/print-routes.js
@@ -65,7 +65,8 @@ function stop (message) {
 }
 
 function cli (args) {
-  printRoutes(args).close()
+  printRoutes(args)
+    .then(fastify => fastify.close())
 }
 
 module.exports = { cli, stop, printRoutes }


### PR DESCRIPTION
in fastify-cli **v2.2.0** invoke printRoutes(args).close()  cause error:

```bash
> fastify print-routes app.js
TypeError: printRoutes(...).close is not a function
```

reason:
in file [print-routes.js](https://github.com/fastify/fastify-cli/blob/master/print-routes.js)
[at line 68](https://github.com/fastify/fastify-cli/blob/master/print-routes.js#L68) cli -> invoke printRoutes
[at line 37](https://github.com/fastify/fastify-cli/blob/master/print-routes.js#L37) printRoutes -> invokes runFastify, [which is asynchronously](https://github.com/fastify/fastify-cli/blob/master/print-routes.js#L40) and returns a promise

implementation reference: [PR#193](https://github.com/fastify/fastify-cli/pull/193)